### PR TITLE
Hide `source` on UNIX

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,20 +2,20 @@ package:
     name: mingwpy
     version: 0.1.0
 
-source:
-    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp34-none-win32.whl     # [py34 and win32]
-    fn: mingwpy-0.1.0b3-cp34-none-win32.whl                                                           # [py34 and win32]
-    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp34-none-win_amd64.whl # [py34 and win64]
-    fn: mingwpy-0.1.0b3-cp34-none-win_amd64.whl                                                       # [py34 and win64]
-    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp27-none-win32.whl     # [py27 and win32]
-    fn: mingwpy-0.1.0b3-cp27-none-win32.whl                                                           # [py27 and win32]
-    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp27-none-win_amd64.whl # [py27 and win64]
-    fn: mingwpy-0.1.0b3-cp27-none-win_amd64.whl                                                       # [py27 and win64]
+source:                                                                                                # [win]
+    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp34-none-win32.whl      # [py34 and win32]
+    fn: mingwpy-0.1.0b3-cp34-none-win32.whl                                                            # [py34 and win32]
+    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp34-none-win_amd64.whl  # [py34 and win64]
+    fn: mingwpy-0.1.0b3-cp34-none-win_amd64.whl                                                        # [py34 and win64]
+    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp27-none-win32.whl      # [py27 and win32]
+    fn: mingwpy-0.1.0b3-cp27-none-win32.whl                                                            # [py27 and win32]
+    url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp27-none-win_amd64.whl  # [py27 and win64]
+    fn: mingwpy-0.1.0b3-cp27-none-win_amd64.whl                                                        # [py27 and win64]
 
 build:
     number: 1
-    skip: True # [unix]
-    skip: True # [py35]
+    skip: True  # [unix]
+    skip: True  # [py35]
 
 requirements:
     build:


### PR DESCRIPTION
Partially addresses https://github.com/conda-forge/mingwpy-feedstock/issues/4

Hides the source line on UNIX to avoid some issues we are experiencing adding users to teams. Basically this `source` section appears to be empty on UNIX platforms and is causing `conda-build` to fail. Also, fixes the selector spacing.
