### PR TITLE
Re-add source selector

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@ package:
     name: mingwpy
     version: 0.1.0
 
-source:
+source:                                                                                                # [win]
     url: https://anaconda.org/carlkl/mingwpy/0.1.0b3/download/mingwpy-0.1.0b3-cp34-none-win32.whl      # [py34 and win32]
     fn: mingwpy-0.1.0b3-cp34-none-win32.whl                                                            # [py34 and win32]
     sha256: f6b1236a6cb3dc15775c178844e18d2d8a43e2d7a1a4c7cefc683ff507967272                           # [py34 and win32]


### PR DESCRIPTION
As this section will be empty on Linux, it causes us trouble parsing it with our feedstock submodule update script. This fixes it by hiding the whole section on non-Windows platforms. As such, it is a partial reversion of PR ( https://github.com/conda-forge/mingwpy-feedstock/pull/7 ) by re-including the change from PR ( https://github.com/conda-forge/mingwpy-feedstock/pull/5 ). Here is an [example](https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/132453176#L550) of the error we see without this.
