### PR TITLE
Require `pip`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,13 +20,14 @@ source:                                                                         
     sha256: f362fc34c10ff5d59196f04ede66454b394917fccc3420597abe25ec5ace68a6                           # [py27 and win64]
 
 build:
-    number: 1
+    number: 2
     skip: True  # [not win or py35]
 
 requirements:
     build:
         - python
         - setuptools
+        - pip
     run:
         - python
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/mingwpy-feedstock/issues/12

Appears `pip` is required as part of the build here. This has been tested and verified in PR ( https://github.com/conda-forge/mingwpy-feedstock/pull/13 ). Here we break out this discrete change so it can be merged independently of PR ( https://github.com/conda-forge/mingwpy-feedstock/pull/11 ).
